### PR TITLE
Fix update for urxvt

### DIFF
--- a/cwriter/writer_posix.go
+++ b/cwriter/writer_posix.go
@@ -21,7 +21,7 @@ func init() {
 
 func (w *Writer) clearLines() {
 	for i := 0; i < w.lineCount; i++ {
-		fmt.Fprintf(w.out, "%c[%dA", ESC, 0) // move the cursor up
+		fmt.Fprintf(w.out, "%c[%dA", ESC, 1) // move the cursor up
 		fmt.Fprintf(w.out, "%c[2K\r", ESC)   // clear the line
 	}
 }


### PR DESCRIPTION
Move the cursor one line up instead of zero lines. This fixes the bar
updates with urxvt, which does nothing otherwise. Also verified to work
on terminals based on libvte.